### PR TITLE
Automatic update of Serilog.AspNetCore to 8.0.2

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
     <PackageReference Include="Ocelot" Version="23.3.3" />
     <PackageReference Include="Serilog" Version="4.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.AspNetCore` to `8.0.2` from `8.0.1`
`Serilog.AspNetCore 8.0.2` was published at `2024-07-31T22:55:15Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Serilog.AspNetCore` `8.0.2` from `8.0.1`

[Serilog.AspNetCore 8.0.2 on NuGet.org](https://www.nuget.org/packages/Serilog.AspNetCore/8.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
