### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 6.7.0

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Swashbuckle.AspNetCore` to `6.7.0` from `6.6.2`
`Swashbuckle.AspNetCore 6.7.0` was published at `2024-08-01T10:12:28Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Swashbuckle.AspNetCore` `6.7.0` from `6.6.2`

[Swashbuckle.AspNetCore 6.7.0 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/6.7.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
