### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.31.0.96804

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.30.0.95878" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.31.0.96804" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.31.0.96804` from `9.30.0.95878`
`SonarAnalyzer.CSharp 9.31.0.96804` was published at `2024-08-06T14:57:12Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.31.0.96804` from `9.30.0.95878`

[SonarAnalyzer.CSharp 9.31.0.96804 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.31.0.96804)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
