### PR TITLE
Automatic update of Microsoft.AspNetCore.OpenApi to 8.0.8

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Ocelot" Version="23.3.3" />
     <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.OpenApi` to `8.0.8` from `8.0.7`
`Microsoft.AspNetCore.OpenApi 8.0.8` was published at `2024-08-13T12:57:26Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Microsoft.AspNetCore.OpenApi` `8.0.8` from `8.0.7`

[Microsoft.AspNetCore.OpenApi 8.0.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.OpenApi/8.0.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
