### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.32.0.97167

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.31.0.96804" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.32.0.97167` from `9.31.0.96804`
`SonarAnalyzer.CSharp 9.32.0.97167` was published at `2024-08-14T09:21:14Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.32.0.97167` from `9.31.0.96804`

[SonarAnalyzer.CSharp 9.32.0.97167 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.32.0.97167)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
