### PR TITLE
Automatic update of AspNetCore.HealthChecks.MongoDb to 8.1.0

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `AspNetCore.HealthChecks.MongoDb` to `8.1.0` from `8.0.1`
`AspNetCore.HealthChecks.MongoDb 8.1.0` was published at `2024-08-28T18:01:55Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `AspNetCore.HealthChecks.MongoDb` `8.1.0` from `8.0.1`

[AspNetCore.HealthChecks.MongoDb 8.1.0 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.MongoDb/8.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
