### PR TITLE
Automatic update of AspNetCore.HealthChecks.UI to 8.0.2

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `AspNetCore.HealthChecks.UI` to `8.0.2` from `8.0.1`
`AspNetCore.HealthChecks.UI 8.0.2` was published at `2024-08-29T17:20:43Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `AspNetCore.HealthChecks.UI` `8.0.2` from `8.0.1`

[AspNetCore.HealthChecks.UI 8.0.2 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.UI/8.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
