### PR TITLE
Automatic update of Ocelot to 23.3.4

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
-    <PackageReference Include="Ocelot" Version="23.3.3" />
+    <PackageReference Include="Ocelot" Version="23.3.4" />
     <PackageReference Include="Serilog" Version="4.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Ocelot` to `23.3.4` from `23.3.3`
`Ocelot 23.3.4` was published at `2024-10-03T20:33:44Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Ocelot` `23.3.4` from `23.3.3`

[Ocelot 23.3.4 on NuGet.org](https://www.nuget.org/packages/Ocelot/23.3.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
