### PR TITLE
Automatic update of Microsoft.AspNetCore.OpenApi to 8.0.10

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
     <PackageReference Include="Ocelot" Version="23.3.4" />
     <PackageReference Include="Serilog" Version="4.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.OpenApi` to `8.0.10` from `8.0.8`
`Microsoft.AspNetCore.OpenApi 8.0.10` was published at `2024-10-08T13:37:18Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Microsoft.AspNetCore.OpenApi` `8.0.10` from `8.0.8`

[Microsoft.AspNetCore.OpenApi 8.0.10 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.OpenApi/8.0.10)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
