### PR TITLE
Automatic update of Serilog.Settings.Configuration to 8.0.4

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.Settings.Configuration` to `8.0.4` from `8.0.2`
`Serilog.Settings.Configuration 8.0.4` was published at `2024-10-10T00:09:06Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Serilog.Settings.Configuration` `8.0.4` from `8.0.2`

[Serilog.Settings.Configuration 8.0.4 on NuGet.org](https://www.nuget.org/packages/Serilog.Settings.Configuration/8.0.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
