### PR TITLE
Automatic update of Serilog.AspNetCore to 8.0.3

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Ocelot" Version="23.3.4" />
     <PackageReference Include="Serilog" Version="4.0.2" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.AspNetCore` to `8.0.3` from `8.0.2`
`Serilog.AspNetCore 8.0.3` was published at `2024-10-11T05:58:52Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Serilog.AspNetCore` `8.0.3` from `8.0.2`

[Serilog.AspNetCore 8.0.3 on NuGet.org](https://www.nuget.org/packages/Serilog.AspNetCore/8.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
