### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 6.9.0

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Swashbuckle.AspNetCore` to `6.9.0` from `6.8.1`
`Swashbuckle.AspNetCore 6.9.0` was published at `2024-10-15T10:56:55Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Swashbuckle.AspNetCore` `6.9.0` from `6.8.1`

[Swashbuckle.AspNetCore 6.9.0 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/6.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
