### PR TITLE
Automatic update of FluentAssertions to 6.12.2

### DIFF
--- a/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
+++ b/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `FluentAssertions` to `6.12.2` from `6.12.1`
`FluentAssertions 6.12.2` was published at `2024-11-08T12:18:14Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj` to `FluentAssertions` `6.12.2` from `6.12.1`

[FluentAssertions 6.12.2 on NuGet.org](https://www.nuget.org/packages/FluentAssertions/6.12.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
