### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 10.3.0.106239

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a major update of `SonarAnalyzer.CSharp` to `10.3.0.106239` from `9.32.0.97167`
`SonarAnalyzer.CSharp 10.3.0.106239` was published at `2024-11-26T14:01:39Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `10.3.0.106239` from `9.32.0.97167`

[SonarAnalyzer.CSharp 10.3.0.106239 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/10.3.0.106239)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
