### PR TITLE
Automatic update of Serilog to 4.2.0

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="Ocelot" Version="23.4.2" />
-    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Serilog` to `4.2.0` from `4.1.0`
`Serilog 4.2.0` was published at `2024-12-06T04:12:49Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Serilog` `4.2.0` from `4.1.0`

[Serilog 4.2.0 on NuGet.org](https://www.nuget.org/packages/Serilog/4.2.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
