### PR TITLE
Automatic update of Serilog.Extensions.Logging to 9.0.0

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `Serilog.Extensions.Logging` to `9.0.0` from `8.0.0`
`Serilog.Extensions.Logging 9.0.0` was published at `2024-12-09T00:19:22Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `Serilog.Extensions.Logging` `9.0.0` from `8.0.0`

[Serilog.Extensions.Logging 9.0.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Extensions.Logging/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
