### PR TITLE
Automatic update of AspNetCore.HealthChecks.UI.InMemory.Storage to 9.0.0

### DIFF
--- a/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
+++ b/HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `AspNetCore.HealthChecks.UI.InMemory.Storage` to `9.0.0` from `8.0.1`
`AspNetCore.HealthChecks.UI.InMemory.Storage 9.0.0` was published at `2024-12-19T10:53:15Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway/HomeBudget.Backend.Gateway.csproj` to `AspNetCore.HealthChecks.UI.InMemory.Storage` `9.0.0` from `8.0.1`

[AspNetCore.HealthChecks.UI.InMemory.Storage 9.0.0 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.UI.InMemory.Storage/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
