### PR TITLE
Automatic update of NUnit.Analyzers to 4.5.0

### DIFF
--- a/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
+++ b/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit.Analyzers` to `4.5.0` from `4.4.0`
`NUnit.Analyzers 4.5.0` was published at `2024-12-22T14:33:52Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj` to `NUnit.Analyzers` `4.5.0` from `4.4.0`

[NUnit.Analyzers 4.5.0 on NuGet.org](https://www.nuget.org/packages/NUnit.Analyzers/4.5.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
