### PR TITLE
Automatic update of NUnit to 4.3.2

### DIFF
--- a/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
+++ b/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit` to `4.3.2` from `4.2.2`
`NUnit 4.3.2` was published at `2024-12-28T21:29:14Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj` to `NUnit` `4.3.2` from `4.2.2`

[NUnit 4.3.2 on NuGet.org](https://www.nuget.org/packages/NUnit/4.3.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
