### PR TITLE
Automatic update of coverlet.collector to 6.0.3

### DIFF
--- a/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
+++ b/HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a patch update of `coverlet.collector` to `6.0.3` from `6.0.2`
`coverlet.collector 6.0.3` was published at `2024-12-30T23:44:27Z`, 7 days ago

1 project update:
Updated `HomeBudget.Backend.Gateway.Api.Tests/HomeBudget.Backend.Gateway.Api.Tests.csproj` to `coverlet.collector` `6.0.3` from `6.0.2`

[coverlet.collector 6.0.3 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/6.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
